### PR TITLE
Handler for method overrides

### DIFF
--- a/method/override.go
+++ b/method/override.go
@@ -10,7 +10,7 @@ import (
 func Override(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "POST" {
-			override := r.Header.Get("_method")
+			override := r.FormValue("_method")
 			switch override {
 			case "PUT", "PATCH", "DELETE":
 				r.Method = override

--- a/method/override_test.go
+++ b/method/override_test.go
@@ -3,6 +3,7 @@ package method
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -24,7 +25,7 @@ func TestDoesntOverrideGET(t *testing.T) {
 
 	req := &http.Request{
 		Method: "GET",
-		Header: map[string][]string{
+		Form: url.Values{
 			"_method": {"DELETE"}},
 	}
 
@@ -37,7 +38,7 @@ func TestOverridesPOSTWithDELETE(t *testing.T) {
 
 	req := &http.Request{
 		Method: "POST",
-		Header: map[string][]string{
+		Form: url.Values{
 			"_method": {"DELETE"}},
 	}
 
@@ -50,7 +51,7 @@ func TestOverridesPOSTWithPUT(t *testing.T) {
 
 	req := &http.Request{
 		Method: "POST",
-		Header: map[string][]string{
+		Form: url.Values{
 			"_method": {"PUT"}},
 	}
 


### PR DESCRIPTION
Provides support for `PUT`, `PATCH` and `DELETE` requests by using a `POST` request together with `_method` parameter which includes the wanted method. 
