### PR TITLE
Make CircuitBreaker public

### DIFF
--- a/breaker/circuit_breaker_test.go
+++ b/breaker/circuit_breaker_test.go
@@ -10,10 +10,10 @@ func afterTest() {
 	now = time.Now
 }
 
-func TestnewBreakerAllows(t *testing.T) {
+func TestNewCircuitBreakerAllows(t *testing.T) {
 	defer afterTest()
 
-	b := newBreaker(0)
+	b := NewCircuitBreaker(0)
 
 	if !b.Allow() {
 		t.Fatal("expected new breaker to be closed")
@@ -23,7 +23,7 @@ func TestnewBreakerAllows(t *testing.T) {
 func TestBreakerSuccessClosesOpenCircuit(t *testing.T) {
 	defer afterTest()
 
-	b := newBreaker(0)
+	b := NewCircuitBreaker(0)
 	b.Trip()
 	if b.Allow() {
 		t.Fatal("expected new breaker to be open in test")
@@ -39,7 +39,7 @@ func TestBreakerSuccessClosesOpenCircuit(t *testing.T) {
 func TestBreakerFailTripsCircuitWithASingleFailureAt0PrecentThreshold(t *testing.T) {
 	defer afterTest()
 
-	b := newBreaker(0)
+	b := NewCircuitBreaker(0)
 
 	for i := 0; i < 100; i++ {
 		b.Success(0)
@@ -56,7 +56,7 @@ func TestBreakerFailDoesNotTripCircuitAt1PrecentThreshold(t *testing.T) {
 
 	const threshold = 0.01
 
-	b := newBreaker(threshold)
+	b := NewCircuitBreaker(threshold)
 
 	for i := 0; i < 100-100*threshold; i++ {
 		b.Success(0)
@@ -83,7 +83,7 @@ func TestBreakerAllowsASingleRequestAfterNapTime(t *testing.T) {
 	timer := make(chan time.Time, 1)
 	after = func(time.Duration) <-chan time.Time { return timer }
 
-	b := newBreaker(0)
+	b := NewCircuitBreaker(0)
 	b.Trip()
 
 	timer <- now()

--- a/breaker/metrics_test.go
+++ b/breaker/metrics_test.go
@@ -36,7 +36,7 @@ func TestErrorRateOverThreshold(t *testing.T) {
 	c.Success(0)
 
 	if ex, s := 0.70, c.Summary(); s.rate < ex {
-		t.Errorf("expected error rate to be over %d%%, got: %f in %+v", ex*100, s, s.rate)
+		t.Errorf("expected error rate to be over %d%%, got: %f in %+v", int(ex*100), s.rate, s)
 	}
 }
 


### PR DESCRIPTION
- The constructor still panics on invalid failureThresholds.
- Made breakerHandler private, as golint was complaining about comments, and it didn't seem to be usable outside of DefaultHandler, anyway.
- Fixed a Printf-args-mismatch in metrics_test.go

Please review and adjust method comments as desired.
