### PR TITLE
Add Accept-Encoding to CORS headers.

### DIFF
--- a/cors/cors.go
+++ b/cors/cors.go
@@ -27,7 +27,7 @@ func Get(origin string, next http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Methods", "GET")
-		w.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type, Origin")
+		w.Header().Set("Access-Control-Allow-Headers", "Accept, Accept-Encoding, Authorization, Content-Type, Origin")
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 
 		switch r.Method {

--- a/cors/cors_test.go
+++ b/cors/cors_test.go
@@ -41,9 +41,9 @@ func TestGetPreflightGet(t *testing.T) {
 		t.Fatalf("expected Access-Control-Origin for OPTIONS, got: %s", hdr)
 	}
 
-	for _, hdr := range []string{"Origin", "Accept", "Content-Type"} {
+	for _, hdr := range []string{"Origin", "Accept", "Accept-Encoding", "Authorization", "Content-Type"} {
 		if hdrs := resp.HeaderMap.Get("Access-Control-Allow-Headers"); !strings.Contains(hdrs, hdr) {
-			t.Fatalf("expected Access-Control-Allow-Headers to include Origin, got: %s", hdrs)
+			t.Fatalf("expected Access-Control-Allow-Headers to include %s, got: %s", hdr, hdrs)
 		}
 	}
 }
@@ -69,9 +69,9 @@ func TestGet(t *testing.T) {
 		t.Fatalf("expected Access-Control-Origin for OPTIONS, got: %s", hdr)
 	}
 
-	for _, hdr := range []string{"Origin", "Accept", "Content-Type"} {
+	for _, hdr := range []string{"Origin", "Accept", "Accept-Encoding", "Authorization", "Content-Type"} {
 		if hdrs := resp.HeaderMap.Get("Access-Control-Allow-Headers"); !strings.Contains(hdrs, hdr) {
-			t.Fatalf("expected Access-Control-Allow-Headers to include Origin, got: %s", hdrs)
+			t.Fatalf("expected Access-Control-Allow-Headers to include %s, got: %s", hdr, hdrs)
 		}
 	}
 }


### PR DESCRIPTION
- Also ensure the tests pick up all of the headers and correctly communicate what is missing.
