### PR TITLE
Adding retrying transport package

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2013, SoundCloud Ltd.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the README file.
+// Source code and contact info at http://github.com/streadway/handy
+
+/*
+Package retry contains a retrying HTTP transport.
+*/
+package retry
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"time"
+)
+
+type Strategy int
+type Event int
+
+type EventHandler func(Event, error)
+type DelayFunc func(uint) time.Duration
+
+const (
+	Timeout Event = iota
+	LimitReached
+	Success
+	BadHTTPStatus
+	EOFRetry
+)
+
+const (
+	Linear Strategy = iota
+	Exponential
+	Fibonacci
+	Custom
+	Constant
+)
+
+type Transport struct {
+	// Minimum HTTP status to satisfy the roundtrip
+	MinHTTPStatus uint
+
+	// Maximum HTTP status to satisfy the roundtrip (exclusive limit)
+	MaxHTTPStatus uint
+
+	// Max number of retries
+	MaxRetries uint
+
+	// Should we retry on EOF (when remote socket closed)
+	RetryOnEOF bool
+
+	// Response time-out
+	ResponseTimeout time.Duration
+
+	// Delay time-constant
+	DelayTimebase time.Duration
+
+	// Type of retry strategy
+	Strategy Strategy
+
+	// Next is the http.RoundTripper on which requests are retried.
+	Next http.RoundTripper
+
+	// Optional callback
+	EventHandler EventHandler
+
+	// Optional custom delay function
+	DelayFunc DelayFunc
+
+	// Possibiity to read a copy of the last response (even if not satisfying desired criterias)
+	lastResponse http.Response
+}
+
+func newDefaultTransportAccept3xxs(maxRetries uint, responseTimeout time.Duration, delayTimebase time.Duration, strategy Strategy, eventHandler EventHandler) *Transport {
+	return &Transport{200,
+		400,
+		maxRetries,
+		true,
+		responseTimeout,
+		delayTimebase,
+		strategy,
+		http.DefaultTransport,
+		eventHandler,
+		nil,
+		http.Response{}}
+}
+
+func newDefaultTransportReject3xxs(maxRetries uint, responseTimeout, delayTimebase time.Duration, strategy Strategy, eventHandler EventHandler) *Transport {
+	return &Transport{200,
+		300,
+		maxRetries,
+		true,
+		responseTimeout,
+		delayTimebase,
+		strategy,
+		http.DefaultTransport,
+		eventHandler,
+		nil,
+		http.Response{}}
+}
+
+func newDefaultTransportOnly3xxs(maxRetries uint, responseTimeout, delayTimebase time.Duration, strategy Strategy, eventHandler EventHandler) *Transport {
+	return &Transport{300,
+		400,
+		maxRetries,
+		true,
+		responseTimeout,
+		delayTimebase,
+		strategy,
+		http.DefaultTransport,
+		eventHandler,
+		nil,
+		http.Response{}}
+}
+
+func newDefaultTransportAccept4xxs(maxRetries uint, responseTimeout, delayTimebase time.Duration, strategy Strategy, eventHandler EventHandler) *Transport {
+	return &Transport{200,
+		500,
+		maxRetries,
+		true,
+		responseTimeout,
+		delayTimebase,
+		strategy,
+		http.DefaultTransport,
+		eventHandler,
+		nil,
+		http.Response{}}
+}
+
+// Retries error responses with small number of retries
+func (t Transport) RoundTrip(req *http.Request) (res *http.Response, err error) {
+	// Current iteration
+	var n uint
+	// Measure request start time
+	start := time.Now()
+	// Perform request(s)
+	for {
+		res, err = t.Next.RoundTrip(req)
+
+		// Return non-HTTP errors immediately,
+		// except EOF that might happen if remote socket force-closes connection
+		// which we consider as a retriable server-side failure
+		if err != nil && err != io.EOF || err == io.EOF && !t.RetryOnEOF {
+			return
+		} else if err == io.EOF {
+			t.NotifyHandler(EOFRetry, fmt.Errorf("Retrying on EOF, retrial %d of %d", n, t.MaxRetries))
+		}
+
+		// If err is nil we can assume response is not nil (store copy of response anyway if client wants to analyze further)
+		t.lastResponse = *res
+
+		// Happy path. :)
+		if res.StatusCode >= int(t.MinHTTPStatus) && res.StatusCode < int(t.MaxHTTPStatus) {
+			t.NotifyHandler(Success, fmt.Errorf("Request succeeded"))
+			return
+		} else {
+			t.NotifyHandler(BadHTTPStatus, fmt.Errorf("Bad HTTP response status (%d), retrial %d of %d", res.StatusCode, n, t.MaxRetries))
+		}
+
+		// Somewhat obey the default response timeout by checking we haven't
+		// exceeded it including retries.
+		if time.Since(start) > t.ResponseTimeout {
+			err = fmt.Errorf("Exceeded response timeout (%f seconds)", t.ResponseTimeout.Seconds())
+			t.NotifyHandler(Timeout, err)
+			return nil, err
+		}
+
+		// Check and eventually break loop before doing any sleep
+		if n >= t.MaxRetries {
+			err = fmt.Errorf("Max retries reached (%d)", t.MaxRetries)
+			t.NotifyHandler(LimitReached, err)
+			break
+		}
+
+		// Apply sleep function with current delay value
+		n++
+		time.Sleep(t.Delay(n))
+	}
+
+	return nil, err
+}
+
+func (t *Transport) NotifyHandler(e Event, err error) {
+	if t.EventHandler != nil {
+		t.EventHandler(e, err)
+	}
+}
+
+// Default DelayFunc implementation
+func (t Transport) Delay(iteration uint) time.Duration {
+	switch t.Strategy {
+	case Constant:
+		return t.DelayTimebase
+	case Linear:
+		return t.DelayTimebase * time.Duration(iteration)
+	case Exponential:
+		return time.Duration(float64(t.DelayTimebase) * math.Exp(float64(iteration)))
+	case Fibonacci:
+		return t.DelayTimebase * time.Duration(fib(int(iteration)))
+	case Custom:
+		if t.DelayFunc != nil {
+			return t.DelayFunc(iteration)
+		}
+	}
+	return 0
+}
+
+func fib(i int) int {
+	var n0, n1, j int
+	for n0, n1, j = 0, 1, 0; j < i; j++ {
+		n0, n1 = n1, n0+n1
+	}
+	return n0
+}

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -1,0 +1,93 @@
+package retry
+
+import (
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type testHandler struct {
+	statusOne int
+	statusTwo int
+	threshold int
+	counter   *int
+	t         *testing.T
+}
+
+func (h testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if *h.counter >= h.threshold {
+		w.WriteHeader(h.statusTwo)
+	} else {
+		w.WriteHeader(h.statusOne)
+	}
+	*h.counter++
+	h.t.Logf("Requests counted: %d", *h.counter)
+}
+
+/* Generic test with 1 second time-base for delay generator */
+func testDefaultTransportAccept3xxsGeneric(t *testing.T, retries, expectedDuration, expectedStatus, goodStatus, badStatus int, strategy Strategy) *Transport {
+	counter := 0
+	expectedCount := retries + 1
+	handler := testHandler{badStatus, goodStatus, retries, &counter, t}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	transport := newDefaultTransportAccept3xxs(uint(retries), 10*time.Second, 1*time.Second, strategy, func(e Event, err error) {
+		t.Logf("Event type %d, message: %s", e, err.Error())
+	})
+
+	retryClient := http.Client{
+		Transport: transport,
+	}
+
+	t.Logf("Trying request ...")
+
+	// Measure request start time
+	start := time.Now()
+
+	resp, err := retryClient.Get(server.URL)
+
+	duration := int(math.Floor(time.Since(start).Seconds()))
+
+	if err != nil {
+		t.Logf("Got resulting error message (no HTTP response): %s", err.Error())
+	} else {
+		t.Logf("Got HTTP response, performing validation checks ...")
+
+		if resp.StatusCode != expectedStatus {
+			t.Errorf("Response status code is %d but is expected to be %d", resp.StatusCode, expectedStatus)
+		}
+
+		if counter != expectedCount {
+			t.Errorf("Should have counted %d requests but counted %d", expectedCount, counter)
+		}
+
+		if duration != expectedDuration {
+			t.Errorf("Total transaction duration should be at least %d seconds but measured %d seconds", expectedDuration, duration)
+		}
+	}
+
+	return transport
+}
+
+func TestDefaultTransportAccept3xxsFibonacci(t *testing.T) {
+	// The combination of input values is critical to pass the test
+	testDefaultTransportAccept3xxsGeneric(t, 5, 12, 200, 200, 400, Fibonacci)
+}
+
+func TestDefaultTransportAccept3xxsConstant(t *testing.T) {
+	// The combination of input values is critical to pass the test
+	testDefaultTransportAccept3xxsGeneric(t, 5, 5, 200, 200, 400, Constant)
+}
+
+func TestTimeout(t *testing.T) {
+	// The combination of input values is critical to pass the test
+	testDefaultTransportAccept3xxsGeneric(t, 11, 10, 400, 200, 400, Constant)
+}
+
+func TestMaxRetries(t *testing.T) {
+	// The combination of input values is critical to pass the test
+	testDefaultTransportAccept3xxsGeneric(t, 2, 2, 400, 400, 400, Constant)
+}


### PR DESCRIPTION
 One retrying roundtrip implementation, some general purpose constructors and a test suite
- Use default HTTP transport or pass in custom implementation
- Setup acceptable status code ranges, retry on EOF, a delay time-base, max retries and global timeout
- Backoff-delay strategies: Constant, Linear, Exponential, Fibonacci or implement your custom delay function and pass it into the constructor
- Pass an event handler callback to do custom analysis of errors and intermediate (unsuccessful) responses
- Use convenience constructors for general purpose and most use-cases, adapt fields after construction if necessary
