### PR TITLE
Adds CancelRequest function to retry transport 

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -96,3 +96,7 @@ func (t Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	panic("unreachable")
 }
+
+func (t *Transport) CancelRequest(req *Request) {
+	t.Next.CancelRequest(req)
+}


### PR DESCRIPTION
Allows the request to timeout and re-use the connection (attempt a retry right away)

Otherwise the underlying transport returns the following error net/http: Client Transport of type *retry.Transport doesn't support CancelRequest; Timeout not supported
