### PR TITLE
Add link to godoc website in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Collection of useful HTTP handlers that form a handler stack of filters.  Many
 are opinionated for a specific purpose.
 
+[![GoDoc](https://godoc.org/github.com/streadway/handy?status.svg)](https://godoc.org/github.com/streadway/handy)
+
 # API
 
 The signature for a handler wrapper ends with an http.Handler interface and returns a http.Handler interface.  For example:


### PR DESCRIPTION
Hey, code is nicely documented, I guess would be good to have a link to godoc website for quick reference.
