### PR TITLE
Add Accept handler

### DIFF
--- a/accept/accept.go
+++ b/accept/accept.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2015, SoundCloud Ltd.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the README file.
+// Source code and contact info at http://github.com/streadway/handy
+
+/*
+Package accept contains filters to reject requests without a specified Accept
+header with "406 Not Acceptable".
+*/
+package accept
+
+import (
+	"mime"
+	"net/http"
+	"strings"
+)
+
+const (
+	// ALL matches all media types.
+	ALL = "*/*"
+)
+
+var (
+	// EventStream matches media typs used for SSE events.
+	EventStream = Middleware("text/event-stream", "text/*")
+
+	// HTML matches media typs used for HTML encoded resources.
+	HTML = Middleware("text/html")
+
+	// JSON matches media typs used for JSON encoded resources.
+	JSON = Middleware("application/json", "application/javascript")
+
+	// Plain matches media typs used for plaintext resources.
+	Plain = Middleware("text/plain")
+
+	// XML matches media typs used for XML encoded resources.
+	XML = Middleware("application/xhtml+xml", "application/xml")
+)
+
+// Middleware returns a composable handler factory to restrict accepted
+// media types and respond with "406 Not Acceptable" otherwise.
+func Middleware(mediaTypes ...string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !acceptable(r.Header.Get("Accept"), mediaTypes) {
+				w.WriteHeader(http.StatusNotAcceptable)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func acceptable(accept string, mediaTypes []string) bool {
+	if accept == "" || accept == ALL {
+		// The absense of an Accept header is equivalent to "*/*".
+		// https://tools.ietf.org/html/rfc2296#section-4.2.2
+		return true
+	}
+
+	for _, a := range strings.Split(accept, ",") {
+		mediaType, _, err := mime.ParseMediaType(a)
+		if err != nil {
+			continue
+		}
+
+		if mediaType == ALL {
+			return true
+		}
+
+		for _, t := range mediaTypes {
+			if mediaType == t {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/accept/accept_test.go
+++ b/accept/accept_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2015, SoundCloud Ltd.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the README file.
+// Source code and contact info at http://github.com/streadway/handy
+
+package accept
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMiddleware(t *testing.T) {
+	tests := []struct {
+		accept     string
+		middleware func(http.Handler) http.Handler
+		code       int
+	}{
+		{
+			accept:     "",
+			middleware: Middleware(),
+			code:       http.StatusOK,
+		},
+		{
+			accept:     "text/plain",
+			middleware: Middleware("text/plain"),
+			code:       http.StatusOK,
+		},
+		{
+			accept:     "text/plain",
+			middleware: Middleware("application/json"),
+			code:       http.StatusNotAcceptable,
+		},
+		{
+			accept:     "text/event-stream",
+			middleware: EventStream,
+			code:       http.StatusOK,
+		},
+		{
+			accept:     "text/html",
+			middleware: HTML,
+			code:       http.StatusOK,
+		},
+		{
+			accept:     "application/json",
+			middleware: JSON,
+			code:       http.StatusOK,
+		},
+		{
+			accept:     "text/plain",
+			middleware: Plain,
+			code:       http.StatusOK,
+		},
+		{
+			accept:     "application/xml",
+			middleware: XML,
+			code:       http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		w, r := httptest.NewRecorder(), newRequest(tt.accept)
+		tt.middleware(okHandler).ServeHTTP(w, r)
+
+		if want, got := tt.code, w.Code; want != got {
+			t.Fatalf("%s want status %d, got %d", tt.accept, want, got)
+		}
+	}
+}
+
+func TestAcceptable(t *testing.T) {
+	tests := []struct {
+		accept string
+		types  []string
+		want   bool
+	}{
+		{
+			accept: "",
+			want:   true,
+		},
+		{
+			accept: "*/*",
+			want:   true,
+		},
+		{
+			accept: "text/plain",
+			want:   false,
+		},
+		{
+			accept: "text/plain",
+			types:  []string{"text/plain"},
+			want:   true,
+		},
+		{
+			accept: "text/html, text/plain",
+			types:  []string{"text/plain"},
+			want:   true,
+		},
+		{
+			accept: "text/html, text/plain",
+			types:  []string{"text/*", "text/html"},
+			want:   true,
+		},
+		{
+			accept: "text/html, text/plain, */*",
+			types:  []string{"application/json"},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		if want, got := tt.want, acceptable(tt.accept, tt.types); want != got {
+			if tt.want {
+				t.Errorf("want accept '%s' to pass (%s)", tt.accept, tt.types)
+			} else {
+				t.Errorf("want accept '%s' to not pass (%s)", tt.accept, tt.types)
+			}
+		}
+	}
+}
+
+var okHandler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {}
+
+func newRequest(accept string) *http.Request {
+	return &http.Request{Header: map[string][]string{
+		"Accept": []string{accept},
+	}}
+}


### PR DESCRIPTION
Adds a handler to restrict accepted media-types and respond with "406 Not
Acceptable" otherwise.

---

Largely inspired by @bernerdschaefer's [eventsource/handler](https://github.com/bernerdschaefer/eventsource/blob/master/handler.go). Thanks!