### PR TITLE
encoding: add one more test for Gzipper

### DIFF
--- a/encoding/gzip_test.go
+++ b/encoding/gzip_test.go
@@ -153,3 +153,20 @@ func TestGzipper_WriteHeader(t *testing.T) {
 		}
 	}
 }
+func TestGzipper_WithoutAcceptEncoding(t *testing.T) {
+	const msg = `Fear is the little-death that brings total obliteration.`
+	srv := httptest.NewServer(Gzipper(gzip.DefaultCompression)(plain(msg)))
+	defer srv.Close()
+
+	req, _ := http.NewRequest("GET", srv.URL, nil)
+	req.Header.Set("Accept-Encoding", "")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	got := resp.Header.Get("Content-Encoding")
+	if got != "" {
+		t.Fatal("content encoding wasn't defined")
+	}
+}


### PR DESCRIPTION
Hi! Added one more test for checking Gzipper method(check request w/o accepted encoding) at `encoding package`
Before this, coverge of `encoding` was
```
go test -coverprofile gzip
PASS
coverage: 92.5% of statements
ok  	github.com/streadway/handy/encoding	0.007s
```

After this
```
go test -coverprofile gzip
PASS
coverage: 97.5% of statements
ok  	github.com/saromanov/handy/encoding	0.006s
```

Please review it