### PR TITLE
Add selective logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/streadway/handy
+
+go 1.16

--- a/report/event.go
+++ b/report/event.go
@@ -56,3 +56,7 @@ func (e *eventRecorder) WriteHeader(code int) {
 	e.event.Status = code
 	e.ResponseWriter.WriteHeader(code)
 }
+
+type Reporter interface {
+	Report(Event)
+}

--- a/report/filter.go
+++ b/report/filter.go
@@ -1,0 +1,23 @@
+package report
+
+// Filter passes events through selectively.
+type Filter struct {
+	selector func(e Event) bool
+	next     Reporter
+}
+
+// Initialize a new Filter that reports events to the next Reporter only if the
+// selector function returns true.
+func NewFilter(selector func(e Event) bool, next Reporter) Filter {
+	return Filter{
+		selector: selector,
+		next:     next,
+	}
+}
+
+// Report implements the Reporter interface.
+func (f Filter) Report(e Event) {
+	if f.selector(e) {
+		f.next.Report(e)
+	}
+}

--- a/report/http.go
+++ b/report/http.go
@@ -1,0 +1,47 @@
+package report
+
+import (
+	"net/http"
+	"time"
+)
+
+// HTTPMiddleware returns a composable factory for HTTP handlers that report the
+// result to the given Reporter.
+func HTTPMiddleware(reporter Reporter) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			writer := &eventRecorder{
+				ResponseWriter: w,
+				event: Event{
+					// Size & Status possiblly overwritten by the ResponseWriter interface
+					Status:         200,
+					Time:           time.Now().UTC(),
+					Method:         r.Method,
+					Url:            r.RequestURI,
+					Path:           r.URL.Path,
+					Proto:          r.Proto,
+					Host:           r.Host,
+					RemoteAddr:     r.RemoteAddr,
+					ForwardedFor:   r.Header.Get("X-Forwarded-For"),
+					ForwardedProto: r.Header.Get("X-Forwarded-Proto"),
+					Authorization:  r.Header.Get("Authorization"),
+					Referrer:       r.Header.Get("Referer"),
+					UserAgent:      r.Header.Get("User-Agent"),
+					Range:          r.Header.Get("Range"),
+					RequestId:      r.Header.Get("X-Request-Id"),
+					Region:         r.Header.Get("X-Region"),
+					Country:        r.Header.Get("X-Country"),
+					City:           r.Header.Get("X-City"),
+				},
+			}
+
+			start := time.Now()
+
+			next.ServeHTTP(writer, r)
+
+			writer.event.Ms = int(time.Since(start) / time.Millisecond)
+
+			reporter.Report(writer.event)
+		})
+	}
+}

--- a/report/json.go
+++ b/report/json.go
@@ -10,79 +10,38 @@ import (
 	"io"
 	"net/http"
 	"sync"
-	"time"
 )
 
-type ShouldLogger func(Event) bool
+// JSONReporter is an event sink that writes serializes into JSON.
+type JSONReporter struct {
+	mu  sync.Mutex
+	out *json.Encoder
+}
 
-// always classifies all events as loggable.
-func always(_ Event) bool {
-	return true
+// NewJSONReporter initializes a new JSONReporter writing to the given
+// io.Writer. Concurrent event reports are written out one after another.
+func NewJSONReporter(w io.Writer) *JSONReporter {
+	return &JSONReporter{
+		mu:  sync.Mutex{},
+		out: json.NewEncoder(w),
+	}
+}
+
+// Report implements the Reporter interface.
+func (r *JSONReporter) Report(e Event) {
+	r.mu.Lock()
+	_ = r.out.Encode(e)
+	r.mu.Unlock()
 }
 
 // JSONMiddleware returns a composable handler factory implementing the JSON
 // handler.
 func JSONMiddleware(writer io.Writer) func(http.Handler) http.Handler {
-	return SelectiveJSONMiddleware(writer, always)
-}
-
-// SelectiveJSONMiddleware returns a composable handler factory implementing the
-// SelectiveJSON handler.
-func SelectiveJSONMiddleware(writer io.Writer, shouldLog ShouldLogger) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		var mu sync.Mutex // serializes encodings
-		out := json.NewEncoder(writer)
-
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			writer := &eventRecorder{
-				ResponseWriter: w,
-				event: Event{
-					// Size & Status possiblly overwritten by the ResponseWriter interface
-					Status:         200,
-					Time:           time.Now().UTC(),
-					Method:         r.Method,
-					Url:            r.RequestURI,
-					Path:           r.URL.Path,
-					Proto:          r.Proto,
-					Host:           r.Host,
-					RemoteAddr:     r.RemoteAddr,
-					ForwardedFor:   r.Header.Get("X-Forwarded-For"),
-					ForwardedProto: r.Header.Get("X-Forwarded-Proto"),
-					Authorization:  r.Header.Get("Authorization"),
-					Referrer:       r.Header.Get("Referer"),
-					UserAgent:      r.Header.Get("User-Agent"),
-					Range:          r.Header.Get("Range"),
-					RequestId:      r.Header.Get("X-Request-Id"),
-					Region:         r.Header.Get("X-Region"),
-					Country:        r.Header.Get("X-Country"),
-					City:           r.Header.Get("X-City"),
-				},
-			}
-
-			start := time.Now()
-
-			next.ServeHTTP(writer, r)
-
-			writer.event.Ms = int(time.Since(start) / time.Millisecond)
-
-			if shouldLog(writer.event) {
-				mu.Lock()
-				_ = out.Encode(writer.event)
-				mu.Unlock()
-			}
-		})
-	}
+	return HTTPMiddleware(NewJSONReporter(writer))
 }
 
 // JSON writes a JSON encoded Event to the provided writer at the
 // completion of each request.
 func JSON(writer io.Writer, next http.Handler) http.Handler {
 	return JSONMiddleware(writer)(next)
-}
-
-// SelectiveJSON writes a JSON encoded event to the provided writer at the
-// completion of each request, if the ShouldLogger called with this event
-// returned true.
-func SelectiveJSON(writer io.Writer, shouldLog ShouldLogger, next http.Handler) http.Handler {
-	return SelectiveJSONMiddleware(writer, shouldLog)(next)
 }

--- a/report/json_test.go
+++ b/report/json_test.go
@@ -96,10 +96,11 @@ func TestJSONShouldHaveMs(t *testing.T) {
 	}
 }
 
-func TestSelectiveJSON(t *testing.T) {
+func TestFilteredJSON(t *testing.T) {
 	var (
-		r, w    = io.Pipe()
-		handler = SelectiveJSON(w, notFoo, sleeper(0))
+		r, w = io.Pipe()
+		// Construct a middleware that only logs certain events.
+		handler = HTTPMiddleware(NewFilter(notFoo, NewJSONReporter(w)))(sleeper(0))
 		logger  = json.NewDecoder(r)
 		paths   = []string{
 			"/foo",

--- a/report/json_test.go
+++ b/report/json_test.go
@@ -70,7 +70,7 @@ func TestMultipleJSONLogLines(t *testing.T) {
 		if ms, ok := report["ms"].(float64); !ok {
 			t.Fatalf("ms is not a number")
 		} else {
-			if want, got, delta := worktime, time.Duration(ms)*time.Millisecond, time.Millisecond; want+delta < got || want-delta > got {
+			if want, got, delta := worktime, time.Duration(ms)*time.Millisecond, worktime/2; want+delta < got || want-delta > got {
 				t.Fatalf("duration falls outside of %s±%s, got: %d", want, delta, got)
 			}
 		}


### PR DESCRIPTION
In high-volume services, it is not always useful to log all requests.
Allow specifying a classifying function that can inspect the event to
decide whether it should be logged.

For convenience, keep the existing behavior under the existing names, by
supplying a trivial classifier.
